### PR TITLE
Update scene.hpp

### DIFF
--- a/include/scene.hpp
+++ b/include/scene.hpp
@@ -10,76 +10,179 @@
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
+#include <typeindex>
+#include <type_traits>
+#include <tuple>
+
+// Simple type-based hashing for a parameter pack of Components
+// (We combine the typeid.hash_code() calls in a stable manner.)
+namespace detail {
+
+/**
+ * Combine hash codes by a simple formula. 
+ * You can switch to a more sophisticated approach as needed.
+ */
+inline std::size_t combine_hash(std::size_t lhs, std::size_t rhs) {
+    // This is a typical Fowler–Noll–Vo or Boost combine approach:
+    lhs ^= (rhs + 0x9e3779b97f4a7c15ULL + (lhs << 6) + (lhs >> 2));
+    return lhs;
+}
+
+/**
+ * Compute a hash for a pack of types `Components...`.
+ * We'll fold each type's hash_code() into a single size_t.
+ */
+template <typename... Components>
+inline std::size_t type_pack_hash() {
+    std::size_t seed = 0;
+    // Using a braced-init-list fold pattern:
+    (void)std::initializer_list<int>{
+        (seed = combine_hash(seed, typeid(Components).hash_code()), 0)...
+    };
+    return seed;
+}
+
+} // namespace detail
+
+// Use a base struct to store the "any" of your cached view
+struct ViewCacheBase {
+    virtual ~ViewCacheBase() = default;
+    bool dirty = true; // If dirty, we must rebuild
+};
+
+template <typename... Components>
+struct ViewCache : public ViewCacheBase {
+    // Store the actual cached view
+    utils::sparse_set_view<Components...> cachedView;
+
+    ViewCache(utils::sparse_set_view<Components...> view)
+        : cachedView(std::move(view)) {
+        dirty = false;
+    }
+};
 
 class Scene {
 #ifdef IMGUI
-	// Needed for signal list menu
-	friend class SystemManager;
+    // Needed for signal list menu
+    friend class SystemManager;
 #endif
 
-      public:
-	Scene() : mEntityManager(new EntityManager()), mComponentManager(new ComponentManager()), mSignals() {}
-	Scene(Scene&&) = delete;
-	Scene(const Scene&) = delete;
-	Scene& operator=(Scene&&) = delete;
-	Scene& operator=(const Scene&) = delete;
-	~Scene() {
-		delete mEntityManager;
-		delete mComponentManager;
-	}
+  public:
+    Scene()
+        : mEntityManager(new EntityManager())
+        , mComponentManager(new ComponentManager())
+        , mSignals() {
+    }
 
-	// This returns a UUID for a new entity
-	[[nodiscard]] EntityID newEntity() {
-		const EntityID entity = mEntityManager->getEntity();
+    Scene(Scene&&) = delete;
+    Scene(const Scene&) = delete;
+    Scene& operator=(Scene&&) = delete;
+    Scene& operator=(const Scene&) = delete;
 
-		return entity;
-	}
-	// Adds a component to an entity
-	template <typename Component, typename... Args> void emplace(const EntityID entity, Args&&... args) {
-		mComponentManager->getPool<Component>()->emplace(entity, args...);
-	}
+    ~Scene() {
+        delete mEntityManager;
+        delete mComponentManager;
+    }
 
-	// Returns the component of the entity
-	template <typename Component> [[nodiscard]] Component& get(const EntityID entity) const {
-		return mComponentManager->getPool<Component>()->get(entity);
-	}
+    // This returns a UUID for a new entity
+    [[nodiscard]] EntityID newEntity() {
+        const EntityID entity = mEntityManager->getEntity();
+        return entity;
+    }
 
-	// Returns weather a entity contains a component
-	template <typename Component> [[nodiscard]] bool contains(const EntityID entity) const {
-		return mComponentManager->getPool<Component>()->contains(entity);
-	}
+    // Adds a component to an entity
+    template <typename Component, typename... Args>
+    void emplace(const EntityID entity, Args&&... args) {
+        mComponentManager->getPool<Component>()->emplace(entity, std::forward<Args>(args)...);
+        // Mark entire view cache as dirty because we changed the pools
+        markAllCachesDirty();
+    }
 
-	// Returns a view of the components
-	template <typename... Components> [[nodiscard]] utils::sparse_set_view<Components...> view() {
-		return utils::sparse_set_view<Components...>(mComponentManager);
-	}
+    // Returns the component of the entity
+    template <typename Component>
+    [[nodiscard]] Component& get(const EntityID entity) const {
+        return mComponentManager->getPool<Component>()->get(entity);
+    }
 
-	void erase(const EntityID entity) noexcept {
-		SDL_assert(entity != 0);
+    // Returns whether an entity contains a component
+    template <typename Component>
+    [[nodiscard]] bool contains(const EntityID entity) const {
+        return mComponentManager->getPool<Component>()->contains(entity);
+    }
 
-		mComponentManager->erase(entity);
-		mEntityManager->releaseEntity(entity);
-	}
+    // Returns a view of the given pack of components
+    template <typename... Components>
+    [[nodiscard]] utils::sparse_set_view<Components...> view() {
+        // 1) Compute a type-based hash for (Components...)
+        std::size_t key = detail::type_pack_hash<Components...>();
 
-	[[nodiscard]] bool valid(const EntityID entity) noexcept { return mEntityManager->valid(entity); }
+        // 2) Look up in our cache
+        auto it = mViewCache.find(key);
+        if (it != mViewCache.end()) {
+            // We have an existing cache
+            auto* basePtr = it->second.get();
+            // Check if it’s the correct typed cache
+            auto* typedPtr = dynamic_cast<ViewCache<Components...>*>(basePtr);
+            if (typedPtr && !typedPtr->dirty) {
+                // It's valid and not dirty => just return it
+                return typedPtr->cachedView;
+            }
+            // else we must rebuild (or typedPtr is null -- which shouldn't normally happen)
+        }
 
-	[[nodiscard]] std::int64_t& getSignal(const std::uint64_t signal) noexcept {
-		if (!mSignals.contains(signal)) {
-			mSignals[signal] = false;
-		}
+        // 3) Build a new view
+        auto newView = utils::sparse_set_view<Components...>(mComponentManager);
+        // 4) Store in the cache
+        auto newCache = std::make_unique<ViewCache<Components...>>(std::move(newView));
+        utils::sparse_set_view<Components...> result = newCache->cachedView; // copy out
+        mViewCache[key] = std::move(newCache);
 
-		return mSignals[signal];
-	}
-	void clearSignals() noexcept { mSignals.clear(); }
+        return result; // Return the newly built or updated view
+    }
 
-	struct {
-		Components::Item item = static_cast<Components::Item>(0);
-		std::uint64_t count = 0;
-	} mMouse;
+    // Remove an entity
+    void erase(const EntityID entity) noexcept {
+        SDL_assert(entity != 0);
+        mComponentManager->erase(entity);
+        mEntityManager->releaseEntity(entity);
+        markAllCachesDirty();
+    }
 
-      private:
-	class EntityManager* mEntityManager;
-	class ComponentManager* mComponentManager;
+    [[nodiscard]] bool valid(const EntityID entity) noexcept {
+        return mEntityManager->valid(entity);
+    }
 
-	std::unordered_map<std::uint64_t, std::int64_t> mSignals;
+    [[nodiscard]] std::int64_t& getSignal(const std::uint64_t signal) noexcept {
+        if (!mSignals.contains(signal)) {
+            mSignals[signal] = false;
+        }
+        return mSignals[signal];
+    }
+
+    void clearSignals() noexcept { mSignals.clear(); }
+
+    // A structure used e.g. for the mouse
+    struct {
+        Components::Item item = static_cast<Components::Item>(0);
+        std::uint64_t count = 0;
+    } mMouse;
+
+  private:
+    // Mark entire view cache as dirty, because any change in the pools invalidates all cached views
+    void markAllCachesDirty() {
+        for (auto& [_, cachePtr] : mViewCache) {
+            if (cachePtr) {
+                cachePtr->dirty = true;
+            }
+        }
+    }
+
+  private:
+    class EntityManager* mEntityManager;
+    class ComponentManager* mComponentManager;
+
+    std::unordered_map<std::uint64_t, std::int64_t> mSignals;
+
+    // The type-based cache container
+    mutable std::unordered_map<std::size_t, std::unique_ptr<ViewCacheBase>> mViewCache;
 };


### PR DESCRIPTION
Below is an example of how you might modify scene.hpp to implement caching of the view results. The idea is: every time you add or remove a component (via emplace or erase), we mark the caches as dirty. Then, on view<Components...>(), we do a type-based lookup to see if we already built that view. If so and it’s not dirty, we reuse it; otherwise we rebuild.

Note: This approach is fairly flexible but somewhat conceptual; you’ll need to adapt or refine it to your own codebase’s specifics.

Explanation of Key Changes
ViewCacheBase: A polymorphic base class that holds a bool dirty;. ViewCache<Components...>: A derived struct that specifically stores a sparse_set_view<Components...> object. We set dirty = false initially once constructed. mViewCache: A std::unordered_map<std::size_t, std::unique_ptr<ViewCacheBase>>, keyed by a computed hash of the type pack (Components...). markAllCachesDirty(): Called in emplace and erase so any change to the pools forces all cached views to be recomputed. (A more advanced approach might track only specific component types that changed, but this is simpler.) In view<Components...>(), we:
Compute a hash from the type IDs for (Components...). Check if we have that entry in mViewCache.
If found and not dirty, reuse; else we build a new sparse_set_view<Components...> and store it. Thread Safety: If your architecture is multi-threaded, you might need extra locking or concurrency strategies. For now, the above example is simpler and does not address concurrency. With these changes, you are now caching the results of the view() calls and only rebuilding them if the underlying component set changed. This can be a considerable optimization if you call view() repeatedly.