### PR TITLE
Add Spanish and Brazilian Portuguese locales

### DIFF
--- a/assets/strings/strings.csv
+++ b/assets/strings/strings.csv
@@ -1,6 +1,6 @@
-id,comment,en,fr,zh-CN
-AD0,,Did you know? This game was developed during 7+ months!,Tu savais ? Cette jeux été déveloper dans plus de 7 mois!,你知道吗？这个游戏的开发周期长于7个月！
-AD1,,Did you know? This game uses its custom engine!,Tu savais ? Cette jeux utilise sa propre moteur de jeux!,你知道吗？这个游戏用的是自己的引擎！
-AD2,,Did you know? This game was coded entirely in C++!,Tu savais ? Cette jeux été crée entièrement avec C++!,你知道吗？这个游戏是完全用C++写的！
-AD3,,Did you know? This game handles (almost) everything by itself!,Tu savais ? Cette jeux fait tout par lui même!,你知道吗？这个游戏自己掌控所有东西！
-AD4,,Did you know? This game gets 1000+ FPS natively!,Tu savais ? Cette jeux fait plus de 1000+ FPS!,你知道吗？这个游戏有1000+ FPS！
+id,comment,en,fr,zh-CN,pt-BR,es
+AD0,,Did you know? This game was developed during 7+ months!,Tu savais ? Cette jeux été déveloper dans plus de 7 mois!,你知道吗？这个游戏的开发周期长于7个月！,Você sabia? Este jogo foi desenvolvido ao longo de mais de 7 meses!,¿Sabías que? ¡Este juego fue desarrollado durante más de 7 meses!
+AD1,,Did you know? This game uses its custom engine!,Tu savais ? Cette jeux utilise sa propre moteur de jeux!,你知道吗？这个游戏用的是自己的引擎！,Você sabia? Este jogo usa a própria engine!,¿Sabías que? ¡Este juego usa su propio motor!
+AD2,,Did you know? This game was coded entirely in C++!,Tu savais ? Cette jeux été crée entièrement avec C++!,你知道吗？这个游戏是完全用C++写的！,Você sabia? Este jogo foi feito inteiramente em C++!,¿Sabías que? ¡Este juego fue hecho completamente en C++!
+AD3,,Did you know? This game handles (almost) everything by itself!,Tu savais ? Cette jeux fait tout par lui même!,你知道吗？这个游戏自己掌控所有东西！,Você sabia? Este jogo cuida de (quase) tudo sozinho!,¿Sabías que? ¡Este juego maneja (casi) todo por sí mismo!
+AD4,,Did you know? This game gets 1000+ FPS natively!,Tu savais ? Cette jeux fait plus de 1000+ FPS!,你知道吗？这个游戏有1000+ FPS！,Você sabia? Este jogo roda a mais de 1000 FPS nativamente!,¿Sabías que? ¡Este juego funciona a más de 1000 FPS de forma nativa!

--- a/cmake/localize.py
+++ b/cmake/localize.py
@@ -14,7 +14,7 @@ if len(sys.argv) != 2:
 
     exit(1);
 
-with open(sys.argv[1]) as input: 
+with open(sys.argv[1], encoding="utf-8", newline="") as input: 
     r = csv.reader(input);
     
     langs = next(r);
@@ -36,6 +36,6 @@ for i in range(len(langs[2:])):
 
         data[row[0]] = row[i+2];
 
-    with open(outDir + "/" + langs[i+2] + ".json", "w") as output:
-        json.dump(data, output);
+    with open(outDir + "/" + langs[i+2] + ".json", "w", encoding="utf-8", newline="") as output:
+        json.dump(data, output, ensure_ascii=False);
 

--- a/include/managers/localeManager.hpp
+++ b/include/managers/localeManager.hpp
@@ -16,13 +16,13 @@ class LocaleManager {
 
 	void changeLocale(const std::string_view& locale) {
 		mLocale = locale;
-		loadLocale();
+		(void)loadLocale();
 	}
 	std::u32string get(const std::string_view& id) const;
 
       private:
 	std::u32string U8toU32(const std::string_view& u8) const;
-	void loadLocale();
+	[[nodiscard]] bool loadLocale();
 
 	const std::string mLocaleDir;
 	std::string mLocale;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -276,7 +276,7 @@ void Game::gui() {
 		ImGui::Text("ESC to close menu");
 		ImGui::Text("Right click to interract");
 
-		const char* locales[] = {"en", "fr"};
+		const char* locales[] = {"en", "fr", "zh-CN", "pt-BR", "es"};
 		static int current = 0;
 		if (ImGui::Combo("language", &current, locales, IM_ARRAYSIZE(locales))) {
 			mLocaleManager->changeLocale(locales[current]);

--- a/src/managers/localeManager.cpp
+++ b/src/managers/localeManager.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 #include <version>
 
 LocaleManager::LocaleManager() : mLocaleDir(getBasePath() + "assets/strings/"), mLocaleDataS(nullptr, SDL_free) {
@@ -29,6 +30,10 @@ LocaleManager::LocaleManager() : mLocaleDir(getBasePath() + "assets/strings/"), 
 	SDL_Log("LocaleManager.cpp: Found locales %s", locList.data());
 
 	for (int i = 0; i < c; ++i) {
+		if (loc[i]->language == nullptr) {
+			continue;
+		}
+
 		mLocale = loc[i]->language;
 		if (loc[i]->country != nullptr) {
 			mLocale.append("-");
@@ -37,20 +42,22 @@ LocaleManager::LocaleManager() : mLocaleDir(getBasePath() + "assets/strings/"), 
 
 		SDL_Log("LocaleManager.cpp: Tring to load locale %s", mLocale.data());
 
-		loadLocale();
+		if (loadLocale()) {
+			SDL_Log("\033[32mLocaleManager.cpp: Successfully loaded system locale %s\033[0m", mLocale.data());
 
-		SDL_Log("\033[32mLocaleManager.cpp: Successfully loaded system locale %s\033[0m", mLocale.data());
+			SDL_free(loc);
 
-		SDL_free(loc);
-
-		return;
+			return;
+		}
 	}
 
 	SDL_free(loc);
 
-	mLocale = "en-US";
-	SDL_Log("\033[31mLocaleManager.cpp: Failed to find valid locale! Falling back to en-US.\033[0m");
-	loadLocale();
+	mLocale = "en";
+	SDL_Log("\033[31mLocaleManager.cpp: Failed to find valid system locale! Falling back to en.\033[0m");
+	if (!loadLocale()) {
+		SDL_LogCritical(SDL_LOG_CATEGORY_VIDEO, "LocaleManager.cpp: Failed to load fallback locale en");
+	}
 }
 
 std::u32string LocaleManager::U8toU32(const std::string_view& u8) const {
@@ -96,47 +103,59 @@ std::u32string LocaleManager::get(const std::string_view& id) const {
 	return U8toU32(mLocaleData[id.data()].GetString());
 }
 
-void LocaleManager::loadLocale() {
-	SDL_Log("LocaleManager.cpp: Loading %s", mLocale.data());
+bool LocaleManager::loadLocale() {
+	const std::string requestedLocale = mLocale;
+	SDL_Log("LocaleManager.cpp: Loading %s", requestedLocale.data());
 
-	std::string main;
+	std::string main = requestedLocale;
 
 #ifdef __cpp_lib_string_contains
-	if (mLocale.contains('-')) {
+	if (requestedLocale.contains('-')) {
 #else
-	if (mLocale.find('-') != std::string::npos) {
+	if (requestedLocale.find('-') != std::string::npos) {
 #endif
-		const std::size_t pos = mLocale.find('-');
-		main = mLocale.substr(0, pos);
-	} else {
-		main = mLocale;
+		const std::size_t pos = requestedLocale.find('-');
+		main = requestedLocale.substr(0, pos);
 	}
 
-	// Prefer specialized locale to generalized one
-	mLocaleDataS.reset(static_cast<char*>(loadFile((mLocaleDir + mLocale + ".json").data(), nullptr)));
+	std::vector<std::string> candidates = {requestedLocale};
+	if (main != requestedLocale) {
+		candidates.emplace_back(main);
+	}
+	if (main != "en" && requestedLocale != "en") {
+		candidates.emplace_back("en");
+	}
 
-	if (!mLocaleDataS) {
-		mLocaleDataS.reset(static_cast<char*>(loadFile((mLocaleDir + main + ".json").data(), nullptr)));
-
-		if (!mLocaleDataS) {
-			SDL_LogCritical(SDL_LOG_CATEGORY_VIDEO,
-					"LocaleManager.cpp: Failed to find/read locale shource %s: %s\n",
-					(mLocaleDir + mLocale + ".json").data(), SDL_GetError());
-			return;
+	for (const auto& candidate : candidates) {
+		std::unique_ptr<char[], std::function<void(char*)>> localeDataS(
+			static_cast<char*>(loadFile((mLocaleDir + candidate + ".json").data(), nullptr)), SDL_free);
+		if (!localeDataS) {
+			continue;
 		}
+
+		rapidjson::Document localeData;
+		if (localeData.ParseInsitu(localeDataS.get()).HasParseError()) {
+			SDL_LogCritical(SDL_LOG_CATEGORY_VIDEO, "\033[31mFailed to parse json %s (offset %u): %s\033[0m",
+					(mLocaleDir + candidate + ".json").data(), (unsigned)localeData.GetErrorOffset(),
+					rapidjson::GetParseError_En(localeData.GetParseError()));
+			ERROR_BOX("Failed to load save file");
+			ERROR_BOX("Failed to read locale, reinstall assets");
+
+			return false;
+		}
+
+		mLocale = candidate;
+		mLocaleData.Swap(localeData);
+		mLocaleDataS = std::move(localeDataS);
+
+		SDL_Log("LocaleManager.cpp: Found locale %s version %d", mLocale.data(), mLocaleData["version"].GetInt());
+		SDL_Log("LocaleManager.cpp: Successfully loaded locale %s", mLocale.data());
+
+		return true;
 	}
 
-	if (mLocaleData.ParseInsitu(mLocaleDataS.get()).HasParseError()) {
-		SDL_LogCritical(SDL_LOG_CATEGORY_VIDEO, "\033[31mFailed to parse json (offset %u): %s\033[0m",
-				(unsigned)mLocaleData.GetErrorOffset(),
-				rapidjson::GetParseError_En(mLocaleData.GetParseError()));
-		ERROR_BOX("Failed to load save file");
-		ERROR_BOX("Failed to read locale, reinstall assets");
-
-		return;
-	}
-
-	SDL_Log("LocaleManager.cpp: Found locale %s version %d", mLocale.data(), mLocaleData["version"].GetInt());
-
-	SDL_Log("LocaleManager.cpp: Successfully loaded locale %s", mLocale.data());
+	SDL_LogCritical(SDL_LOG_CATEGORY_VIDEO,
+			"LocaleManager.cpp: Failed to find/read locale sources for %s, fallback %s and en: %s\n",
+			requestedLocale.data(), main.data(), SDL_GetError());
+	return false;
 }


### PR DESCRIPTION
This pull request expands the game's localization support and improves locale handling robustness. The main changes are the addition of new languages, enhancements to locale fallback logic, and updates to the localization pipeline to better handle Unicode and CSV parsing.

Localization expansion:

* Added support for Portuguese (Brazil) and Spanish translations in the `strings.csv` file, updating all "Did you know?" lines to include these languages.
* Updated the language selection UI in `Game::gui()` to include the new locales: `zh-CN`, `pt-BR`, and `es`.

Locale handling improvements:

* Refactored the `LocaleManager` to improve locale fallback logic: now attempts to load the requested locale, then its base language, and finally falls back to `en` if none are available, with detailed logging for failures and successes. [[1]](diffhunk://#diff-9514fb1cb423b2150ed7e166a34db06a39058b983fc36eb6f46cfe4fdef55d48R33-R36) [[2]](diffhunk://#diff-9514fb1cb423b2150ed7e166a34db06a39058b983fc36eb6f46cfe4fdef55d48L40-R60) [[3]](diffhunk://#diff-9514fb1cb423b2150ed7e166a34db06a39058b983fc36eb6f46cfe4fdef55d48L99-R160)
* Changed `loadLocale()` to return a boolean indicating success, and updated its usage throughout the codebase for better error handling. [[1]](diffhunk://#diff-e1b8354122eb4128e6526dfe553ef6a052888618b1b661a2ca4af27f19204b0eL19-R25) [[2]](diffhunk://#diff-9514fb1cb423b2150ed7e166a34db06a39058b983fc36eb6f46cfe4fdef55d48L40-R60) [[3]](diffhunk://#diff-9514fb1cb423b2150ed7e166a34db06a39058b983fc36eb6f46cfe4fdef55d48L99-R160)

Localization pipeline updates:

* Updated the Python localization script to handle UTF-8 encoding and line endings when reading and writing CSV and JSON files, and to output JSON with Unicode characters preserved. [[1]](diffhunk://#diff-0e5b1d012be1950152d55604a5a5ba57ba945fcc3ad575644b33dd172e0c8840L17-R17) [[2]](diffhunk://#diff-0e5b1d012be1950152d55604a5a5ba57ba945fcc3ad575644b33dd172e0c8840L39-R40)

Other improvements:

* Added `#include <vector>` to `localeManager.cpp` to support new locale candidate logic.